### PR TITLE
Fixed Numismatic Overhaul compatibility

### DIFF
--- a/src/main/java/terramine/common/init/ModProfessions.java
+++ b/src/main/java/terramine/common/init/ModProfessions.java
@@ -12,7 +12,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 import terramine.TerraMine;
 
-import java.util.Collections;
+import java.util.List;
 
 public class ModProfessions {
     public static final PoiType GOBLIN_TINKERER_POI = register("goblin_tinkerer", 1, 1, ModBlocks.TINKERER_TABLE);
@@ -23,31 +23,32 @@ public class ModProfessions {
         //ItemsForEmeralds: i = costEmerald, j = numberOfItems, k = maxUses, l = villagerXp, f = priceMultiplier
 
         // GOBLIN_TINKERER TRADES
-        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 1, allTradesList -> Collections.addAll(allTradesList, new VillagerTrades.ItemListing[]{
-                new VillagerTrades.ItemsForEmeralds(ModItems.ROCKET_BOOTS,10, 1,1,10),
-                new VillagerTrades.EmeraldForItems(Items.DISPENSER, 5,15, 2)
-        }));
-        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 2, allTradesList -> Collections.addAll(allTradesList, new VillagerTrades.ItemListing[]{
-                new VillagerTrades.ItemsForEmeralds(ModItems.STOPWATCH,5, 1,1,10),
-                new VillagerTrades.EmeraldForItems(Items.STICKY_PISTON, 7,20, 4)
-        }));
-        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 3, allTradesList -> Collections.addAll(allTradesList, new VillagerTrades.ItemListing[]{
-                new VillagerTrades.ItemsForEmeralds(ModItems.WEATHER_RADIO,7, 1,1,15),
-                new VillagerTrades.ItemsForEmeralds(ModItems.SEXTANT,10, 1,1,15)
-        }));
-        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 4, allTradesList -> Collections.addAll(allTradesList, new VillagerTrades.ItemListing[]{
-                new VillagerTrades.EmeraldForItems(Items.OBSERVER, 10,15, 15),
-                new VillagerTrades.ItemsForEmeralds(ModItems.EXTENDO_GRIP,20, 1,1,15)
-        }));
-        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 5, allTradesList -> Collections.addAll(allTradesList, new VillagerTrades.ItemListing[]{
-                new VillagerTrades.ItemsForEmeralds(ModItems.TOOLBELT,20, 1,1,30),
-                new VillagerTrades.ItemsForEmeralds(ModItems.TOOLBOX,20, 1,1,30)
-        }));
+        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 1, factories -> factories.addAll(List.of(
+                new VillagerTrades.ItemsForEmeralds(ModItems.ROCKET_BOOTS, 10, 1, 1, 10),
+                new VillagerTrades.EmeraldForItems(Items.DISPENSER, 5, 15, 2)
+        )));
+        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 2, factories -> factories.addAll(List.of(
+                new VillagerTrades.ItemsForEmeralds(ModItems.STOPWATCH, 5, 1, 1, 10),
+                new VillagerTrades.EmeraldForItems(Items.STICKY_PISTON, 7, 20, 4)
+        )));
+        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 3, factories -> factories.addAll(List.of(
+                new VillagerTrades.ItemsForEmeralds(ModItems.WEATHER_RADIO, 7, 1, 1, 15),
+                new VillagerTrades.ItemsForEmeralds(ModItems.SEXTANT, 10, 1, 1, 15)
+        )));
+        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 4, factories -> factories.addAll(List.of(
+                new VillagerTrades.EmeraldForItems(Items.OBSERVER, 10, 15, 15),
+                new VillagerTrades.ItemsForEmeralds(ModItems.EXTENDO_GRIP, 20, 1, 1, 15)
+        )));
+        TradeOfferHelper.registerVillagerOffers(GOBLIN_TINKERER, 5, factories -> factories.addAll(List.of(
+                new VillagerTrades.ItemsForEmeralds(ModItems.TOOLBELT, 20, 1, 1, 30),
+                new VillagerTrades.ItemsForEmeralds(ModItems.TOOLBOX, 20, 1, 1, 30)
+        )));
     }
 
     private static PoiType register(String name, int tickCount, int searchDistance, Block block) {
         return PointOfInterestHelper.register(TerraMine.id(name), tickCount, searchDistance, block);
     }
+
     private static VillagerProfession register(String name, PoiType poi, SoundEvent sound) {
         var key = Registry.POINT_OF_INTEREST_TYPE.getResourceKey(poi).orElseThrow();
         return Registry.register(Registry.VILLAGER_PROFESSION, TerraMine.id(name), VillagerProfessionBuilder.create().id(TerraMine.id(name)).workstation(holder -> holder.is(key)).jobSite(holder -> holder.is(key)).workSound(sound).build());

--- a/src/main/resources/data/numismatic-overhaul/villager_trades/goblin_tinkerer.json
+++ b/src/main/resources/data/numismatic-overhaul/villager_trades/goblin_tinkerer.json
@@ -3,18 +3,18 @@
   "trades": {
     "novice": [
       {
-        "type": "numismatic-overhaul:buy_stack",
+        "type": "numismatic-overhaul:sell_stack",
         "price": 50000,
-        "buy": {
+        "sell": {
           "item": "terramine:rocket_boots",
           "count": 1
         },
         "max_uses": 1
       },
       {
-        "type": "numismatic-overhaul:sell_stack",
+        "type": "numismatic-overhaul:buy_stack",
         "price": 2000,
-        "sell": {
+        "buy": {
           "item": "minecraft:dispenser",
           "count": 1
         },
@@ -24,18 +24,18 @@
     ],
 	"apprentice": [
       {
-        "type": "numismatic-overhaul:buy_stack",
+        "type": "numismatic-overhaul:sell_stack",
         "price": 50000,
-        "buy": {
+        "sell": {
           "item": "terramine:stopwatch",
           "count": 1
         },
         "max_uses": 1
       },
       {
-        "type": "numismatic-overhaul:sell_stack",
+        "type": "numismatic-overhaul:buy_stack",
         "price": 1500,
-        "sell": {
+        "buy": {
           "item": "minecraft:sticky_piston",
           "count": 1
         },
@@ -45,18 +45,18 @@
     ],
 	"journeyman": [
       {
-        "type": "numismatic-overhaul:buy_stack",
+        "type": "numismatic-overhaul:sell_stack",
         "price": 50000,
-        "buy": {
+        "sell": {
           "item": "terramine:weather_radio",
           "count": 1
         },
         "max_uses": 1
       },
       {
-        "type": "numismatic-overhaul:buy_stack",
+        "type": "numismatic-overhaul:sell_stack",
         "price": 50000,
-        "buy": {
+        "sell": {
           "item": "terramine:sextant",
           "count": 1
         },
@@ -65,9 +65,9 @@
     ],
 	"expert": [
 	{
-        "type": "numismatic-overhaul:sell_stack",
+        "type": "numismatic-overhaul:buy_stack",
         "price": 2500,
-        "sell": {
+        "buy": {
           "item": "minecraft:observer",
           "count": 1
         },
@@ -75,9 +75,9 @@
         "villager_experience": 15
       },
       {
-        "type": "numismatic-overhaul:buy_stack",
+        "type": "numismatic-overhaul:sell_stack",
         "price": 50000,
-        "buy": {
+        "sell": {
           "item": "terramine:extendo_grip",
           "count": 1
         },
@@ -86,18 +86,18 @@
     ],
 	"master": [
       {
-        "type": "numismatic-overhaul:buy_stack",
+        "type": "numismatic-overhaul:sell_stack",
         "price": 50000,
-        "buy": {
+        "sell": {
           "item": "terramine:toolbelt",
           "count": 1
         },
         "max_uses": 1
       },
       {
-        "type": "numismatic-overhaul:buy_stack",
+        "type": "numismatic-overhaul:sell_stack",
         "price": 50000,
-        "buy": {
+        "sell": {
           "item": "terramine:toolbox",
           "count": 1
         },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -63,7 +63,8 @@
     "cardinal-components-entity": ">=4.0.0",
     "cloth-config2": ">=7.0",
     "step-height-entity-attribute": "*",
-    "reach-entity-attributes": ">=2.3.0"
+    "reach-entity-attributes": ">=2.3.0",
+    "architectury": ">=5.6.22"
   },
   "suggests": {
     "modmenu": "*"


### PR DESCRIPTION
Related to https://github.com/wisp-forest/numismatic-overhaul/issues/43
This commit fixes the trades provided by Terramine. 

Thank you for adding trades by the way, it exposed multiple issues regarding our compatibility with the Fabric Villager Trade API. All of these are fixed and are scheduled for next release. 

Signed-off-by: Noaaan <noaaan@hotmail.com>